### PR TITLE
Styles for pdf download link

### DIFF
--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -158,3 +158,10 @@
 .landing .software-docs-list .sidebarblock a:hover {
   color: rgba(255, 255, 255, 0.8);
 }
+
+.landing .pdf-download {
+  font-size: 90%;
+  font-weight: 600;
+  background: url(../img/pdf.svg) no-repeat left top;
+  padding-left: 1.5rem;
+}

--- a/src/img/pdf.svg
+++ b/src/img/pdf.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="none" d="M0 0h24v24H0z"/>
+    <path fill="white" d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8.5 7.5c0 .83-.67 1.5-1.5 1.5H9v2H7.5V7H10c.83 0 1.5.67 1.5 1.5v1zm5 2c0 .83-.67 1.5-1.5 1.5h-2.5V7H15c.83 0 1.5.67 1.5 1.5v3zm4-3H19v1h1.5V11H19v2h-1.5V7h3v1.5zM9 9.5h1v-1H9v1zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm10 5.5h1v-3h-1v3z"/>
+  </svg>


### PR DESCRIPTION
Styles for "download pdf" link in the landing page.

These links need to be wrapped under`.pdf-download` class from the content repo.

Demo:
<img width="1051" alt="Screenshot 2019-05-28 at 17 25 34" src="https://user-images.githubusercontent.com/466018/58490624-c51de580-816d-11e9-93e8-c0b1687cc708.png">
